### PR TITLE
Fix Trusty build

### DIFF
--- a/prepare-chroot-qubuntu
+++ b/prepare-chroot-qubuntu
@@ -112,16 +112,16 @@ wc -L "${DIR}/var/lib/apt/lists/"*InRelease | awk '$1 > 1024 {print; exit 1}'
 # ------------------------------------------------------------------------------
 chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -y install $BUILDPACKAGES
 
-if [ $DIST != 'xenial' ]; then
+if [ $DIST = trusty ]; then
 # Install pulseaudio5
 chroot $DIR apt-get $APT_GET_OPTIONS install -y software-properties-common
 chroot $DIR add-apt-repository -y ppa:ubuntu-audio-dev/pulse-testing
 chroot $DIR apt-get $APT_GET_OPTIONS update
 # check for CVE-2016-1252 - directly after debootstrap, still vulnerable
 # apt is installed
+fi
 wc -L "${DIR}/var/lib/apt/lists/"*InRelease | awk '$1 > 1024 {print; exit 1}'
 chroot $DIR apt-get $APT_GET_OPTIONS install -y libpulse-dev
-fi
 
 # ------------------------------------------------------------------------------
 # Update qubuntu apt sources list to use local qubes repo

--- a/template_qubuntu/02_install_groups_trusty.sh
+++ b/template_qubuntu/02_install_groups_trusty.sh
@@ -8,7 +8,7 @@ source "${SCRIPTSDIR}/distribution.sh"
 info 'HACK: Copying utopic sources.list to install systemd'
 #### '--------------------------------------------------------------------------
 cat > "${INSTALLDIR}/etc/apt/sources.list.d/systemd-utopic.list" <<EOF
-deb http://mirror.csclub.uwaterloo.ca/ubuntu/ utopic main
+deb http://old-releases.ubuntu.com/ubuntu/  utopic main
 EOF
 
 #### '--------------------------------------------------------------------------

--- a/template_qubuntu/packages_trusty.list
+++ b/template_qubuntu/packages_trusty.list
@@ -16,7 +16,6 @@ git
 gnome-terminal
 xterm
 libfile-mimeinfo-perl
-libglib2.0-bin
 ltrace
 strace
 haveged


### PR DESCRIPTION
Remove packages from list that are not available in Trusty
Update repo details

One of fixes for QubesOS/qubes-issues#2608.
This is, I think, the final piece.

@marmarek The build regularly fails for me when downloading the GPG key for Launchpad. I suspect that this is to do with my set-up, so have kept Key related material in a separate branch. If people report the issue I'll put in a separate PR for that.
I suspect that the 3.1 Jessie+standard Travis build will fail - it fails on master without this PR.