### PR TITLE
Stretch template - remove wpa-supplicant@ service from multi-user.target

### DIFF
--- a/template_debian/09_cleanup.sh
+++ b/template_debian/09_cleanup.sh
@@ -37,6 +37,7 @@ if [ "$DIST" == "jessie" ]; then
     sed -i '/./{H;$!d};x;/dc_other_hostnames/d'  "${INSTALLDIR}/var/cache/debconf/config.dat-old" || true
     sed -i '/./{H;$!d};x;/exim4\/mailname/d'  "${INSTALLDIR}/var/cache/debconf/config.dat-old" || true
 fi
+rm -f  "${INSTALLDIR}/etc/systemd/system/multi-user.target.wants/wpa_supplicant@.service"
 sed -i "s/`hostname`/$DIST/"  "${INSTALLDIR}/etc/hosts" || true
 
 # ==============================================================================

--- a/template_debian/packages_stretch.list
+++ b/template_debian/packages_stretch.list
@@ -14,5 +14,4 @@ ltrace
 strace
 haveged
 wireless-tools
-wpasupplicant
 dbus-x11


### PR DESCRIPTION
It is responsible for the long start-up delay and is unnecessary.

According to the docs, NetworkManager should be using dbus to connect with wpa_supplicant so this should be no loss.

Closes QubesOS/qubes-issues#2913
