### PR TITLE
Install python-concurrent.futures as a workaround for salt bug

### DIFF
--- a/template_debian/packages_stretch.list
+++ b/template_debian/packages_stretch.list
@@ -14,3 +14,4 @@ haveged
 wireless-tools
 wpasupplicant
 dbus-x11
+python-concurrent.futures


### PR DESCRIPTION
The missing module in salt thin is already fixed upstream and queued for
2018.3.3 (at least). This commit should be reverted when it gets
released and packaged in some Qubes-supported template.

QubesOS/qubes-issues#4272