### PR TITLE
Use HTTPS by default to access apt repositories

### DIFF
--- a/prepare-chroot-debian
+++ b/prepare-chroot-debian
@@ -49,10 +49,11 @@ if ! [ -d $DIR/home/user ]; then
     # --------------------------------------------------------------------------
     mkdir -p $DIR
     echo "-> Installing debian build chroot..."
+    apt_https_pkgs="apt-transport-https,ca-certificates"
     COMPONENTS="" $DEBOOTSTRAP_PREFIX debootstrap --arch=amd64 \
-                --include=ncurses-term,debian-keyring,$eatmydata_maybe \
+                --include=ncurses-term,debian-keyring,$apt_https_pkgs,$eatmydata_maybe \
                 --keyring=${DEBIAN_PLUGIN_DIR}keys/$DIST-debian-archive-keyring.gpg \
-                $DEBIANVERSION $DIR http://http.debian.net/debian \
+                $DEBIANVERSION $DIR https://deb.debian.org/debian \
                 || { echo "Error in debootstrap"; exit 1; }
 
     # --------------------------------------------------------------------------
@@ -119,7 +120,7 @@ chroot $DIR $eatmydata_maybe apt-get $APT_GET_OPTIONS -y install $BUILDPACKAGES
 if [ "$DIST" == "wheezy" ]; then
     # Looks like a SID only package is being used to build packages
     # there is a backport available for wheezy
-    source="deb http://http.debian.net/debian wheezy-backports main"
+    source="deb https://deb.debian.org/debian wheezy-backports main"
     if ! grep -r -q "$source" "${DIR}/etc/apt/sources.list"*; then
         touch "${DIR}/etc/apt/sources.list"
         echo "$source" >> "${DIR}/etc/apt/sources.list"
@@ -131,7 +132,7 @@ fi
 
 if [ "$DIST" == "jessie" ]; then
     # enable jessie-backports for various python3-* packages
-    source="deb http://http.debian.net/debian jessie-backports main"
+    source="deb https://deb.debian.org/debian jessie-backports main"
     if ! grep -r -q "$source" "${DIR}/etc/apt/sources.list"*; then
         touch "${DIR}/etc/apt/sources.list"
         echo "$source" >> "${DIR}/etc/apt/sources.list"
@@ -141,20 +142,20 @@ fi
 # ------------------------------------------------------------------------------
 # Install Debian source repo
 # ------------------------------------------------------------------------------
-source="deb-src http://http.debian.net/debian ${DEBIANVERSION} main"
+source="deb-src https://deb.debian.org/debian ${DEBIANVERSION} main"
 if ! grep -r -q "$source" "${DIR}/etc/apt/sources.list"*; then
     touch "${DIR}/etc/apt/sources.list"
     echo "$source" >> "${DIR}/etc/apt/sources.list"
 fi
 
 if [ -n "$USE_QUBES_REPO_VERSION" ]; then
-    source="deb [arch=amd64] http://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm $DIST main"
+    source="deb [arch=amd64] https://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm $DIST main"
     if ! fgrep -r -q "$source" "${DIR}/etc/apt/sources.list"*; then
         touch "${DIR}/etc/apt/sources.list"
         echo "$source" >> "${DIR}/etc/apt/sources.list"
     fi
     if [ "0$USE_QUBES_REPO_TESTING" -gt 0 ]; then
-        source="deb [arch=amd64] http://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm ${DIST}-testing main"
+        source="deb [arch=amd64] https://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm ${DIST}-testing main"
         if ! fgrep -r -q "$source" "${DIR}/etc/apt/sources.list"*; then
             touch "${DIR}/etc/apt/sources.list"
             echo "$source" >> "${DIR}/etc/apt/sources.list"

--- a/template_debian/01_install_core.sh
+++ b/template_debian/01_install_core.sh
@@ -38,13 +38,14 @@ bootstrap() {
             "${INSTALLDIR}/var/lib/apt/lists/debootstrap.invalid_dists_${DIST}_Release" \
         )
 
+        apt_https_pkgs="apt-transport-https,ca-certificates"
         # Download packages first, and log hash of them _before_ installing
         # them. Needs to copy Release{,.gpg} to a dummy _local_ repo, because
         # debootstrap insists on downloading it each time but we want to be sure to use
         # packages downloaded earlier (and logged)
         COMPONENTS="" $DEBOOTSTRAP_PREFIX debootstrap \
             --arch=amd64 \
-            --include="ncurses-term,locales,tasksel,$eatmydata_maybe" \
+            --include="ncurses-term,locales,tasksel,$apt_https_pkgs,$eatmydata_maybe" \
             --components=main \
             --download-only \
             --keyring="${SCRIPTSDIR}/../keys/${DIST}-${DISTRIBUTION}-archive-keyring.gpg" \
@@ -63,7 +64,7 @@ bootstrap() {
         done && \
         COMPONENTS="" $DEBOOTSTRAP_PREFIX debootstrap \
             --arch=amd64 \
-            --include="ncurses-term,locales,tasksel,$eatmydata_maybe" \
+            --include="ncurses-term,locales,tasksel,$apt_https_pkgs,$eatmydata_maybe" \
             --components=main \
             --keyring="${SCRIPTSDIR}/../keys/${DIST}-${DISTRIBUTION}-archive-keyring.gpg" \
             "${DIST}" "${INSTALLDIR}" "file://${INSTALLDIR}/${TMPDIR}/dummy-repo" && \

--- a/template_debian/distribution.sh
+++ b/template_debian/distribution.sh
@@ -283,11 +283,11 @@ function updateDebianSourceList() {
     fi
 
     # Add Debian security repositories
-    source="deb http://security.debian.org ${DEBIANVERSION}/updates main contrib non-free"
+    source="deb https://deb.debian.org/debian-security ${DEBIANVERSION}/updates main contrib non-free"
     if ! grep -r -q "$source" "${list}"*; then
         echo -e "$source" >> "${list}"
     fi
-    source="#deb-src http://security.debian.org ${DEBIANVERSION}/updates main contrib non-free"
+    source="#deb-src https://deb.debian.org/debian-security ${DEBIANVERSION}/updates main contrib non-free"
     if ! grep -r -q "$source" "${list}"*; then
         echo -e "$source\n" >> "${list}"
     fi
@@ -380,11 +380,11 @@ deb [trusted=yes] file:/tmp/qubes_repo ${DIST} main
 EOF
     if [ -n "$USE_QUBES_REPO_VERSION" ]; then
         cat >> "${INSTALLDIR}/etc/apt/sources.list.d/qubes-builder.list" <<EOF
-deb [arch=amd64] http://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm $DIST main
+deb [arch=amd64] https://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm $DIST main
 EOF
        if [ "0$USE_QUBES_REPO_TESTING" -gt 0 ]; then
           cat >> "${INSTALLDIR}/etc/apt/sources.list.d/qubes-builder.list" <<EOF
-deb [arch=amd64] http://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm ${DIST}-testing main
+deb [arch=amd64] https://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm ${DIST}-testing main
 EOF
         fi
         chroot_cmd apt-key add - < ${SCRIPTSDIR}/../keys/qubes-debian-r${USE_QUBES_REPO_VERSION}.asc

--- a/template_debian/vars.sh
+++ b/template_debian/vars.sh
@@ -25,6 +25,7 @@ DEBIANVERSION=${DIST}
 # Location to grab Debian packages
 # ------------------------------------------------------------------------------
 DEFAULT_DEBIAN_MIRRORS=(
+    'https://deb.debian.org/debian'
     'http://http.debian.net/debian'
     'http://ftp.us.debian.org/debian'
     'http://ftp.ca.debian.org/debian'
@@ -54,6 +55,7 @@ fi
 if [ -n "$REPO_PROXY" ]; then
     APT_GET_OPTIONS+=" -o Acquire::http::Proxy=${REPO_PROXY}"
     DEBOOTSTRAP_PREFIX+=" env http_proxy=${REPO_PROXY}"
+    DEBOOTSTRAP_PREFIX+=" env https_proxy=${REPO_PROXY}"
 fi
 
 containsFlavor 'no-recommends' && {


### PR DESCRIPTION
Switch to https://deb.debian.org/ for both main and security
repositories. Use also deb.qubes-os.org over HTTPS if requested.
This require apt-transport-https installed by default, so add it to
debootstrap call.

QubesOS/qubes-issues#4415