### PR TITLE
Make debian package build reproducible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,19 @@ jobs:
     - script: ~/qubes-builder/scripts/travis-build app-shutdown-idle
       env: DISTS_VM=xenial
 
+    # example "3.0 (quilt)" package, without upstream tarball
+    - script: ~/qubes-builder/scripts/travis-build core-vchan-xen
+      env: DISTS_VM=stretch USE_QUBES_REPO_VERSION=4.0 USE_QUBES_REPO_TESTING=1 USE_DIST_BUILD_TOOLS=1
+    # example "3.0 (native)" package
+    - script: ~/qubes-builder/scripts/travis-build linux-utils
+      env: DISTS_VM=stretch USE_QUBES_REPO_VERSION=4.0 USE_QUBES_REPO_TESTING=1 USE_DIST_BUILD_TOOLS=1
+    # example "3.0 (quilt)" package, with upstream tarball
+    - script: ~/qubes-builder/scripts/travis-build python-u2flib-host
+      env: DISTS_VM=stretch USE_QUBES_REPO_VERSION=4.0 USE_QUBES_REPO_TESTING=1 USE_DIST_BUILD_TOOLS=1
+    # example ubuntu build
+    - script: ~/qubes-builder/scripts/travis-build app-shutdown-idle
+      env: DISTS_VM=xenial USE_DIST_BUILD_TOOLS=1
+
 # don't build tags which are meant for code signing only
 branches:
   except:

--- a/Makefile-legacy.debian
+++ b/Makefile-legacy.debian
@@ -1,4 +1,4 @@
-# This file is included from Makefile.debian if package do not define USE_DIST_BUILD_TOOLS
+# This file is included from Makefile.debian if USE_DIST_BUILD_TOOLS is not set
 
 dist-prepare-chroot: $(CHROOT_DIR)/home/user/.prepared_base
 	@if [ $(VERBOSE) -gt 0 ]; then \

--- a/Makefile-legacy.debian
+++ b/Makefile-legacy.debian
@@ -1,0 +1,63 @@
+# This file is included from Makefile.debian if package do not define USE_DIST_BUILD_TOOLS
+
+dist-prepare-chroot: $(CHROOT_DIR)/home/user/.prepared_base
+	@if [ $(VERBOSE) -gt 0 ]; then \
+		echo "-> dist-prepare-chroot for $(DIST)"; \
+		echo "-> sudo mount --bind $(BUILDER_REPO_DIR) $(CHROOT_DIR)/tmp/qubes-deb;"; \
+	fi
+	@if [ ! -r $(CHROOT_DIR)/proc/cpuinfo ]; then\
+		sudo mount -t proc proc $(CHROOT_DIR)/proc;\
+	fi
+	@if ! [ -d $(CHROOT_DIR)/tmp/qubes-deb/deb ]; then\
+		mkdir -p $(CHROOT_DIR)/tmp/qubes-deb;\
+		sudo mount --bind $(BUILDER_REPO_DIR) $(CHROOT_DIR)/tmp/qubes-deb;\
+	fi
+
+$(CHROOT_DIR)/home/user/.prepared_base: $(DEBIAN_PLUGIN_DIR)/prepare-chroot-$(DISTRIBUTION)
+	# Make sure repo directory exists
+	@if ! [ -d "$(BUILDER_REPO_DIR)/dists" ]; then\
+	    mkdir -p "$(BUILDER_REPO_DIR)/dists";\
+	fi
+	@echo "-> Preparing $(DIST) build environment"
+	@sudo -E $(DEBIAN_PLUGIN_DIR)/prepare-chroot-$(DISTRIBUTION) $(CHROOT_DIR) $(DIST)
+	@touch $(CHROOT_DIR)/home/user/.prepared_base
+
+dist-prep: release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
+dist-prep:
+	@rm -f "$(CHROOT_DIR)/$(DIST_SRC)/../$(release_name)"*
+
+dist-build-dep: 
+	@if ! [ -d "$(BUILDER_REPO_DIR)/dists" ]; then\
+	    mkdir -p "$(BUILDER_REPO_DIR)/dists";\
+	fi
+	$(DEBIAN_PLUGIN_DIR)/update-local-repo.sh $(DIST)
+	sudo chroot $(CHROOT_DIR) apt-get ${APT_GET_OPTIONS} update
+
+	# check for CVE-2016-1252 - directly after debootstrap, still vulnerable
+	# apt is installed
+	wc -L "$(CHROOT_DIR)/var/lib/apt/lists/"*InRelease | awk '$$1 > 1024 {print; exit 1}'
+
+	# update the base system inside
+	sudo chroot $(CHROOT_DIR) apt-get $(APT_GET_OPTIONS) dist-upgrade -y
+
+	# install build dependencies
+	LC_ALL=C sudo chroot $(CHROOT_DIR) mk-build-deps -i -r -t "apt-get --no-install-recommends -y" $(DIST_SRC_DEBIAN_DIR)/control
+
+ifneq (,$(DEBIAN_BUILD_DIRS))
+dist-package:  release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
+endif
+dist-package: debian-prepare-dist-src
+	sudo $(CHROOT_ENV) chroot $(CHROOT_DIR) su $(RUN_AS_USER) -c 'cd $(DIST_SRC_DEBIAN_DIR)/..; export LC_ALL=C; dpkg-buildpackage -sa -uc -us'
+
+ifneq (,$(DEBIAN_BUILD_DIRS))
+dist-copy-out:  release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(CHROOT_DEBIAN_DIR)/changelog)
+endif
+dist-copy-out:
+	mkdir -p $(BUILDER_REPO_DIR)/deb
+	mkdir -p $(ORIG_SRC)/$(OUTPUT_DIR)
+	cd $(CHROOT_DEBIAN_DIR)/../..; \
+		cp -t $(BUILDER_REPO_DIR)/deb `$(listfiles) $(release_name)*.changes`
+	cp -t $(BUILDER_REPO_DIR)/deb/ $(CHROOT_DEBIAN_DIR)/../../$(release_name)*.changes
+	cd $(CHROOT_DEBIAN_DIR)/../..; \
+		mv -t $(PWD)/$(ORIG_SRC)/$(OUTPUT_DIR)  `$(listfiles) $(release_name)*.changes`
+	mv -t $(PWD)/$(ORIG_SRC)/$(OUTPUT_DIR) $(CHROOT_DEBIAN_DIR)/../../$(release_name)*.changes

--- a/Makefile-pbuilder.debian
+++ b/Makefile-pbuilder.debian
@@ -1,17 +1,25 @@
 # This file is included from Makefile.debian if USE_DIST_BUILD_TOOLS is set
 
-dist-prepare-chroot: $(CHROOT_DIR)/.prepared_pbuilder
+PBUILDER_BASEDIR = $(CHROOT_DIR)/pbuilder
+
+dist-prepare-chroot: $(PBUILDER_BASEDIR)/.prepared_pbuilder
 	@true
 
 # TODO: avoid loading user ~/.pbuilderrc
-$(CHROOT_DIR)/.prepared_pbuilder: $(DEBIAN_PLUGIN_DIR)/pbuilderrc
+$(PBUILDER_BASEDIR)/.prepared_pbuilder: $(DEBIAN_PLUGIN_DIR)/pbuilderrc
 	@mkdir -p $(CHROOT_DIR)
+	@if [ $$(stat -c %u $(CHROOT_DIR)) -eq 0 ]; then \
+		sudo mkdir -p $(PBUILDER_BASEDIR); \
+		sudo chown $$UID $(PBUILDER_BASEDIR); \
+	else \
+		mkdir -p $(PBUILDER_BASEDIR); \
+	fi
 	@echo "-> Preparing $(DIST) build environment"
 	$(DEBIAN_PLUGIN_DIR)/update-local-repo.sh $(DIST)
 	if [ -n "$(USE_QUBES_REPO_VERSION)" ]; then \
-		gpg --dearmor < $(DEBIAN_PLUGIN_DIR)keys/qubes-debian-r$(USE_QUBES_REPO_VERSION).asc > $(CHROOT_DIR)/qubes-keyring.gpg; \
+		gpg --dearmor < $(DEBIAN_PLUGIN_DIR)keys/qubes-debian-r$(USE_QUBES_REPO_VERSION).asc > $(PBUILDER_BASEDIR)/qubes-keyring.gpg; \
 	fi
-	if [ -r "$(CHROOT_DIR)/base.tgz" ]; then \
+	if [ -r "$(PBUILDER_BASEDIR)/base.tgz" ]; then \
 		action=update; \
 	else \
 		action=create; \
@@ -20,8 +28,8 @@ $(CHROOT_DIR)/.prepared_pbuilder: $(DEBIAN_PLUGIN_DIR)/pbuilderrc
 		--distribution $(DIST) \
 		--configfile $(DEBIAN_PLUGIN_DIR)/pbuilderrc \
 		--othermirror "deb [trusted=yes] file:/tmp/qubes-deb $(DIST) main" || \
-		{ rm -f "$(CHROOT_DIR)/base.tgz"; exit 1; }
-	@touch $(CHROOT_DIR)/.prepared_pbuilder
+		{ rm -f "$(PBUILDER_BASEDIR)/base.tgz"; exit 1; }
+	@touch $(PBUILDER_BASEDIR)/.prepared_pbuilder
 
 dist-prep: release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
 dist-prep:
@@ -45,7 +53,7 @@ ifndef PACKAGE
 endif
 	$(DEBIAN_PLUGIN_DIR)/update-local-repo.sh $(DIST)
 
-	mkdir -p "$(CHROOT_DIR)/results"
+	mkdir -p "$(PBUILDER_BASEDIR)/results"
 
 	release_name_full=$$($(DEBIAN_PARSER) changelog --package-release-name-full $(CHROOT_DEBIAN_DIR)/changelog); \
 	extra_sources="deb [trusted=yes] file:/tmp/qubes-deb $(DIST) main"; \
@@ -69,5 +77,5 @@ endif
 dist-copy-out:
 	mkdir -p $(BUILDER_REPO_DIR)/deb
 	mkdir -p $(ORIG_SRC)/$(OUTPUT_DIR)
-	dcmd cp -t $(BUILDER_REPO_DIR)/deb $(CHROOT_DIR)/results/$(release_name)*.changes
-	dcmd mv -t $(PWD)/$(ORIG_SRC)/$(OUTPUT_DIR) $(CHROOT_DIR)/results/$(release_name)*.changes
+	dcmd cp -t $(BUILDER_REPO_DIR)/deb $(PBUILDER_BASEDIR)/results/$(release_name)*.changes
+	dcmd mv -t $(PWD)/$(ORIG_SRC)/$(OUTPUT_DIR) $(PBUILDER_BASEDIR)/results/$(release_name)*.changes

--- a/Makefile-pbuilder.debian
+++ b/Makefile-pbuilder.debian
@@ -1,0 +1,73 @@
+# This file is included from Makefile.debian if USE_DIST_BUILD_TOOLS is set
+
+dist-prepare-chroot: $(CHROOT_DIR)/.prepared_pbuilder
+	@true
+
+
+$(CHROOT_DIR)/.prepared_pbuilder: $(DEBIAN_PLUGIN_DIR)/pbuilderrc
+	@mkdir -p $(CHROOT_DIR)
+	@echo "-> Preparing $(DIST) build environment"
+	$(DEBIAN_PLUGIN_DIR)/update-local-repo.sh $(DIST)
+	if [ -n "$(USE_QUBES_REPO_VERSION)" ]; then \
+		gpg --dearmor < $(DEBIAN_PLUGIN_DIR)keys/qubes-debian-r$(USE_QUBES_REPO_VERSION).asc > $(CHROOT_DIR)/qubes-keyring.gpg; \
+	fi
+	if [ -r "$(CHROOT_DIR)/base.tgz" ]; then \
+		action=update; \
+	else \
+		action=create; \
+	fi; \
+	sudo -E pbuilder $$action --basetgz $(CHROOT_DIR)/base.tgz \
+		--distribution $(DIST) \
+		--configfile $(DEBIAN_PLUGIN_DIR)/pbuilderrc \
+		--othermirror "deb [trusted=yes] file:/tmp/qubes-deb $(DIST) main"
+	@touch $(CHROOT_DIR)/.prepared_pbuilder
+
+dist-prep: release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
+dist-prep:
+	@rm -f "$(CHROOT_DIR)/$(DIST_SRC)/../$(release_name)"*
+
+dist-build-dep:
+	@true
+
+.PHONY: build-source-package
+build-source-package: debian-prepare-dist-src
+	cd $(CHROOT_DIR)/$(DIST_SRC)/$(PACKAGE)/.. && \
+	dpkg-source -b .
+
+ifneq (,$(DEBIAN_BUILD_DIRS))
+dist-package:  release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
+dist-package: build-source-package
+endif
+dist-package:
+ifndef PACKAGE
+	$(error "PACKAGE need to be set!")
+endif
+	$(DEBIAN_PLUGIN_DIR)/update-local-repo.sh $(DIST)
+
+	mkdir -p "$(CHROOT_DIR)/results"
+
+	release_name_full=$$($(DEBIAN_PARSER) changelog --package-release-name-full $(CHROOT_DEBIAN_DIR)/changelog); \
+	extra_sources="deb [trusted=yes] file:/tmp/qubes-deb $(DIST) main"; \
+	if [ -n "$(USE_QUBES_REPO_VERSION)" ]; then \
+		extra_sources="$$extra_sources|deb [arch=amd64] http://deb.qubes-os.org/r$(USE_QUBES_REPO_VERSION)/vm $(DIST) main"; \
+		if [ "0$(USE_QUBES_REPO_TESTING)" -gt 0 ]; then \
+			extra_sources="$$extra_sources|deb [arch=amd64] http://deb.qubes-os.org/r$(USE_QUBES_REPO_VERSION)/vm $(DIST)-testing main"; \
+		fi; \
+		gpg --dearmor < $(DEBIAN_PLUGIN_DIR)keys/qubes-debian-r$(USE_QUBES_REPO_VERSION).asc > $(CHROOT_DIR)/qubes-keyring.gpg; \
+	fi; \
+	cd $(CHROOT_DIR)/$(DIST_SRC)/$(PACKAGE)/../.. && \
+	sudo -E pbuilder build --basetgz $(CHROOT_DIR)/base.tgz \
+		--override-config \
+		--distribution $(DIST) \
+		--configfile $(DEBIAN_PLUGIN_DIR)/pbuilderrc \
+		--othermirror "$$extra_sources" \
+		$(CHROOT_DIR)/$(DIST_SRC)/$(PACKAGE)/../../$$release_name_full.dsc
+
+ifneq (,$(DEBIAN_BUILD_DIRS))
+dist-copy-out:  release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(CHROOT_DEBIAN_DIR)/changelog)
+endif
+dist-copy-out:
+	mkdir -p $(BUILDER_REPO_DIR)/deb
+	mkdir -p $(ORIG_SRC)/$(OUTPUT_DIR)
+	dcmd cp -t $(BUILDER_REPO_DIR)/deb $(CHROOT_DIR)/results/$(release_name)*.changes
+	dcmd mv -t $(PWD)/$(ORIG_SRC)/$(OUTPUT_DIR) $(CHROOT_DIR)/results/$(release_name)*.changes

--- a/Makefile-pbuilder.debian
+++ b/Makefile-pbuilder.debian
@@ -3,7 +3,7 @@
 dist-prepare-chroot: $(CHROOT_DIR)/.prepared_pbuilder
 	@true
 
-
+# TODO: avoid loading user ~/.pbuilderrc
 $(CHROOT_DIR)/.prepared_pbuilder: $(DEBIAN_PLUGIN_DIR)/pbuilderrc
 	@mkdir -p $(CHROOT_DIR)
 	@echo "-> Preparing $(DIST) build environment"
@@ -19,7 +19,8 @@ $(CHROOT_DIR)/.prepared_pbuilder: $(DEBIAN_PLUGIN_DIR)/pbuilderrc
 	sudo -E pbuilder $$action --basetgz $(CHROOT_DIR)/base.tgz \
 		--distribution $(DIST) \
 		--configfile $(DEBIAN_PLUGIN_DIR)/pbuilderrc \
-		--othermirror "deb [trusted=yes] file:/tmp/qubes-deb $(DIST) main"
+		--othermirror "deb [trusted=yes] file:/tmp/qubes-deb $(DIST) main" || \
+		{ rm -f "$(CHROOT_DIR)/base.tgz"; exit 1; }
 	@touch $(CHROOT_DIR)/.prepared_pbuilder
 
 dist-prep: release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
@@ -53,7 +54,6 @@ endif
 		if [ "0$(USE_QUBES_REPO_TESTING)" -gt 0 ]; then \
 			extra_sources="$$extra_sources|deb [arch=amd64] http://deb.qubes-os.org/r$(USE_QUBES_REPO_VERSION)/vm $(DIST)-testing main"; \
 		fi; \
-		gpg --dearmor < $(DEBIAN_PLUGIN_DIR)keys/qubes-debian-r$(USE_QUBES_REPO_VERSION).asc > $(CHROOT_DIR)/qubes-keyring.gpg; \
 	fi; \
 	cd $(CHROOT_DIR)/$(DIST_SRC)/$(PACKAGE)/../.. && \
 	sudo -E pbuilder build --basetgz $(CHROOT_DIR)/base.tgz \

--- a/Makefile-pbuilder.debian
+++ b/Makefile-pbuilder.debian
@@ -16,7 +16,7 @@ $(CHROOT_DIR)/.prepared_pbuilder: $(DEBIAN_PLUGIN_DIR)/pbuilderrc
 	else \
 		action=create; \
 	fi; \
-	sudo -E pbuilder $$action --basetgz $(CHROOT_DIR)/base.tgz \
+	sudo -E pbuilder $$action \
 		--distribution $(DIST) \
 		--configfile $(DEBIAN_PLUGIN_DIR)/pbuilderrc \
 		--othermirror "deb [trusted=yes] file:/tmp/qubes-deb $(DIST) main" || \
@@ -56,7 +56,7 @@ endif
 		fi; \
 	fi; \
 	cd $(CHROOT_DIR)/$(DIST_SRC)/$(PACKAGE)/../.. && \
-	sudo -E pbuilder build --basetgz $(CHROOT_DIR)/base.tgz \
+	sudo -E pbuilder build \
 		--override-config \
 		--distribution $(DIST) \
 		--configfile $(DEBIAN_PLUGIN_DIR)/pbuilderrc \

--- a/Makefile.debian
+++ b/Makefile.debian
@@ -177,11 +177,11 @@ endif
 	rm -rf $(CHROOT_DIR)/$(DIST_SRC)/pkgs/*
 
 ifneq (,$(INCREMENT_DEVEL_VERSIONS))
-	# Break the hardlink - keep modified debian/changelog only inside of chroot
+	# Break the hardlink - keep modified debian/changelog only in build copy
 	cp $(CHROOT_DEBIAN_DIR)/changelog $(CHROOT_DEBIAN_DIR)/changelog.copy
 	mv $(CHROOT_DEBIAN_DIR)/changelog.copy $(CHROOT_DEBIAN_DIR)/changelog
 	# Update changelog with -develXX appended to version
-	# Note: INCREMENT_DEVEL_VERSIONS needs to be set to any value in 
+	# Note: INCREMENT_DEVEL_VERSIONS needs to be set to any value in
 	#       builder configuration to use this feature
 	cd $(CHROOT_DIR)/$(DIST_SRC); $(DEBIAN_PLUGIN_DIR)/scripts/debian-changelog.sh
 
@@ -205,7 +205,11 @@ else
 		-exec touch --no-dereference --reference=$(CHROOT_DEBIAN_DIR)/changelog {} +
 endif
 
+ifeq ($(USE_DIST_BUILD_TOOLS),1)
+include $(DEBIAN_PLUGIN_DIR)/Makefile-pbuilder.debian
+else
 include $(DEBIAN_PLUGIN_DIR)/Makefile-legacy.debian
+endif
 
 ifeq (,$(DEBIAN_BUILD_DIRS))
 update-repo:

--- a/Makefile.debian
+++ b/Makefile.debian
@@ -161,53 +161,11 @@ ifdef DEBUG
   $(info ╚═══════════════════════════════════════════════════════════════════════════════)
 endif
 
-dist-prepare-chroot: $(CHROOT_DIR)/home/user/.prepared_base
-	@if [ $(VERBOSE) -gt 0 ]; then \
-		echo "-> dist-prepare-chroot for $(DIST)"; \
-		echo "-> sudo mount --bind $(BUILDER_REPO_DIR) $(CHROOT_DIR)/tmp/qubes-deb;"; \
-	fi
-	@if [ ! -r $(CHROOT_DIR)/proc/cpuinfo ]; then\
-		sudo mount -t proc proc $(CHROOT_DIR)/proc;\
-	fi
-	@if ! [ -d $(CHROOT_DIR)/tmp/qubes-deb/deb ]; then\
-		mkdir -p $(CHROOT_DIR)/tmp/qubes-deb;\
-		sudo mount --bind $(BUILDER_REPO_DIR) $(CHROOT_DIR)/tmp/qubes-deb;\
-	fi
-
-$(CHROOT_DIR)/home/user/.prepared_base: $(DEBIAN_PLUGIN_DIR)/prepare-chroot-$(DISTRIBUTION)
-	# Make sure repo directory exists
-	@if ! [ -d "$(BUILDER_REPO_DIR)/dists" ]; then\
-	    mkdir -p "$(BUILDER_REPO_DIR)/dists";\
-	fi
-	@echo "-> Preparing $(DIST) build environment"
-	@sudo -E $(DEBIAN_PLUGIN_DIR)/prepare-chroot-$(DISTRIBUTION) $(CHROOT_DIR) $(DIST)
-	@touch $(CHROOT_DIR)/home/user/.prepared_base
-
-dist-prep: release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
-dist-prep:
-	@rm -f "$(CHROOT_DIR)/$(DIST_SRC)/../$(release_name)"*
-
-dist-build-dep: 
-	@if ! [ -d "$(BUILDER_REPO_DIR)/dists" ]; then\
-	    mkdir -p "$(BUILDER_REPO_DIR)/dists";\
-	fi
-	$(DEBIAN_PLUGIN_DIR)/update-local-repo.sh $(DIST)
-	sudo chroot $(CHROOT_DIR) apt-get ${APT_GET_OPTIONS} update
-
-	# check for CVE-2016-1252 - directly after debootstrap, still vulnerable
-	# apt is installed
-	wc -L "$(CHROOT_DIR)/var/lib/apt/lists/"*InRelease | awk '$$1 > 1024 {print; exit 1}'
-
-	# update the base system inside
-	sudo chroot $(CHROOT_DIR) apt-get $(APT_GET_OPTIONS) dist-upgrade -y
-
-	# install build dependencies
-	LC_ALL=C sudo chroot $(CHROOT_DIR) mk-build-deps -i -r -t "apt-get --no-install-recommends -y" $(DIST_SRC_DEBIAN_DIR)/control
-
 ifneq (,$(DEBIAN_BUILD_DIRS))
-dist-package:  release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
+debian-prepare-dist-src:  release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(ORIG_SRC)/$(DEBIAN_BUILD_DIRS)/changelog)
 endif
-dist-package:
+# fixups for DIST_SRC dir - adjust changelog, cleanup
+debian-prepare-dist-src:
 ifndef PACKAGE
 	$(error "PACKAGE need to be set!")
 endif
@@ -247,20 +205,7 @@ else
 		-exec touch --no-dereference --reference=$(CHROOT_DEBIAN_DIR)/changelog {} +
 endif
 
-	sudo $(CHROOT_ENV) chroot $(CHROOT_DIR) su $(RUN_AS_USER) -c 'cd $(DIST_SRC_DEBIAN_DIR)/..; export LC_ALL=C; dpkg-buildpackage -sa -uc -us'
-
-ifneq (,$(DEBIAN_BUILD_DIRS))
-dist-copy-out:  release_name = $(shell $(DEBIAN_PARSER) changelog --package-release-name $(CHROOT_DEBIAN_DIR)/changelog)
-endif
-dist-copy-out:
-	mkdir -p $(BUILDER_REPO_DIR)/deb
-	mkdir -p $(ORIG_SRC)/$(OUTPUT_DIR)
-	cd $(CHROOT_DEBIAN_DIR)/../..; \
-		cp -t $(BUILDER_REPO_DIR)/deb `$(listfiles) $(release_name)*.changes`
-	cp -t $(BUILDER_REPO_DIR)/deb/ $(CHROOT_DEBIAN_DIR)/../../$(release_name)*.changes
-	cd $(CHROOT_DEBIAN_DIR)/../..; \
-		mv -t $(PWD)/$(ORIG_SRC)/$(OUTPUT_DIR)  `$(listfiles) $(release_name)*.changes`
-	mv -t $(PWD)/$(ORIG_SRC)/$(OUTPUT_DIR) $(CHROOT_DEBIAN_DIR)/../../$(release_name)*.changes
+include $(DEBIAN_PLUGIN_DIR)/Makefile-legacy.debian
 
 ifeq (,$(DEBIAN_BUILD_DIRS))
 update-repo:

--- a/builder.conf
+++ b/builder.conf
@@ -14,7 +14,11 @@ clean-rpms::
 about::
 	@echo "debian-builder/builder.conf"
 
-DEBIAN_DEPENDENCIES ?= dpkg-dev debootstrap devscripts
+ifeq ($(USE_DIST_BUILD_TOOLS),1)
+DEP_PBUILDER = pbuilder
+endif
+
+DEBIAN_DEPENDENCIES ?= dpkg-dev debootstrap devscripts $(DEP_PBUILDER)
 DEPENDENCIES += $(DEBIAN_DEPENDENCIES)
 
 # vim: filetype=make

--- a/pbuilder-hooks/D30update
+++ b/pbuilder-hooks/D30update
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+apt-get update

--- a/pbuilder-hooks/E30origin
+++ b/pbuilder-hooks/E30origin
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cat >/etc/dpkg/origins/qubes <<EOF
+Vendor: Qubes
+Vendor-URL: https://www.qubes-org.org/
+Bugs: https://github.com/QubesOS/qubes-issues
+EOF

--- a/pbuilderrc
+++ b/pbuilderrc
@@ -1,0 +1,162 @@
+# pbuilder defaults; edit /etc/pbuilderrc to override these and see
+# pbuilderrc.5 for documentation
+
+# Set how much output you want from pbuilder, valid values are
+# E => errors only
+# W => errors and warnings
+# I => errors, warnings and informational
+# D => all of the above and debug messages
+LOGLEVEL=I
+# if positive, some log messagges (errors, warnings, debugs) will be colored
+# auto => try automatically detection
+# yes  => always use colors
+# no   => never use colors
+USECOLORS=auto
+
+BASETGZ=/var/cache/pbuilder/base.tgz
+#EXTRAPACKAGES=""
+#export DEBIAN_BUILDARCH=athlon
+BUILDPLACE=$CHROOT_DIR/build
+# directory inside the chroot where the build happens. See #789404
+BUILDDIR=/build
+# what be used as value for HOME during builds.  See #441052
+# The default value prevents builds to write on HOME, which is prevented on
+# Debian buildds too.  You can set it to $BUILDDIR to get a working HOME, if
+# you need to.
+BUILD_HOME=/nonexistent
+MIRRORSITE=http://httpredir.debian.org/debian
+#OTHERMIRROR="deb http://www.home.com/updates/ ./"
+#export http_proxy=http://your-proxy:8080/
+USEPROC=yes
+USEDEVFS=no
+USEDEVPTS=yes
+USESYSFS=yes
+USENETWORK=no
+USERUNSHM=yes
+BUILDRESULT="${CHROOT_DIR}/results"
+
+# specifying the distribution forces the distribution on "pbuilder update"
+#DISTRIBUTION=sid
+# specifying the architecture passes --arch= to debootstrap; the default is
+# to use the architecture of the host
+#ARCHITECTURE=`dpkg --print-architecture`
+# specifying the components of the distribution, for instance to enable all
+# components on Debian use "main contrib non-free" and on Ubuntu "main
+# restricted universe multiverse"
+COMPONENTS="main"
+#specify the cache for APT
+APTCACHE="$CACHEDIR"
+APTCACHEHARDLINK="yes"
+REMOVEPACKAGES=""
+#HOOKDIR="/usr/lib/pbuilder/hooks"
+HOOKDIR="$DEBIAN_PLUGIN_DIR/pbuilder-hooks"
+EATMYDATA=yes
+
+# make debconf not interact with user
+export DEBIAN_FRONTEND="noninteractive"
+
+#for pbuilder debuild
+BUILDSOURCEROOTCMD="fakeroot"
+PBUILDERROOTCMD="sudo -E"
+# use cowbuilder for pdebuild
+#PDEBUILD_PBUILDER="cowbuilder"
+
+# additional build results to copy out of the package build area
+#ADDITIONAL_BUILDRESULTS=(xunit.xml .coverage)
+
+# command to satisfy build-dependencies; the default is an internal shell
+# implementation which is relatively slow; there are two alternate
+# implementations, the "experimental" implementation,
+# "pbuilder-satisfydepends-experimental", which might be useful to pull
+# packages from experimental or from repositories with a low APT Pin Priority,
+# and the "aptitude" implementation, which will resolve build-dependencies and
+# build-conflicts with aptitude which helps dealing with complex cases but does
+# not support unsigned APT repositories
+PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends"
+
+# Arguments for $PBUILDERSATISFYDEPENDSCMD.
+# PBUILDERSATISFYDEPENDSOPT=()
+
+# You can optionally make pbuilder accept untrusted repositories by setting
+# this option to yes, but this may allow remote attackers to compromise the
+# system. Better set a valid key for the signed (local) repository with
+# $APTKEYRINGS (see below).
+ALLOWUNTRUSTED=no
+
+# Option to pass to apt-get always.
+export APTGETOPT=()
+# Option to pass to aptitude always.
+export APTITUDEOPT=()
+
+# Whether to use debdelta or not.  If "yes" debdelta will be installed in the
+# chroot
+DEBDELTA=no
+
+#Command-line option passed on to dpkg-buildpackage.
+#DEBBUILDOPTS="-IXXX -iXXX"
+DEBBUILDOPTS="-sa"
+
+#APT configuration files directory
+APTCONFDIR=""
+
+# the username and ID used by pbuilder, inside chroot. Needs fakeroot, really
+BUILDUSERNAME=pbuilder
+BUILDUSERID=$(grep $BUILDUSERNAME /etc/passwd | cut -d: -f3)
+
+# BINDMOUNTS is a space separated list of things to mount
+# inside the chroot.
+BINDMOUNTS=""
+
+# Set the debootstrap variant to 'buildd' type.
+DEBOOTSTRAPOPTS=(
+    '--variant=buildd'
+    '--force-check-gpg'
+    )
+# or unset it to make it not a buildd type.
+# unset DEBOOTSTRAPOPTS
+
+# Keyrings to use for package verification with apt, not used for debootstrap
+# (use DEBOOTSTRAPOPTS). By default the debian-archive-keyring package inside
+# the chroot is used.
+if [ -r "${CHROOT_DIR}/qubes-keyring.gpg" ]; then
+    APTKEYRINGS=( "${CHROOT_DIR}/qubes-keyring.gpg" )
+else
+    APTKEYRINGS=()
+fi
+
+# Set the PATH I am going to use inside pbuilder: default is "/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+
+# SHELL variable is used inside pbuilder by commands like 'su'; and they need sane values
+export SHELL=/bin/bash
+
+# The name of debootstrap command, you might want "cdebootstrap".
+DEBOOTSTRAP="debootstrap"
+
+# default file extension for pkgname-logfile
+PKGNAME_LOGFILE_EXTENSION="_$(dpkg --print-architecture).build"
+
+# default PKGNAME_LOGFILE
+PKGNAME_LOGFILE=""
+
+# default AUTOCLEANAPTCACHE
+AUTOCLEANAPTCACHE=""
+
+#default COMPRESSPROG
+COMPRESSPROG="gzip"
+
+# pbuilder copies some configuration files (like /etc/hosts or /etc/hostname)
+# from the host system into the chroot.  If the directory specified here
+# exists and contains one of the copied files (without the leading /etc) that
+# file will be copied from here instead of the system one
+CONFDIR="/etc/pbuilder/conf_files"
+
+# ccache (make sure ccache is installed before uncommenting)
+CCACHEDIR=""
+# Note: CCACHEDIR is private to pbuilder, ccache uses "CCACHE_DIR"
+#CCACHEDIR="/var/cache/pbuilder/ccache"
+#export CCACHE_DIR="${CCACHEDIR}"
+#export PATH="/usr/lib/ccache:${PATH}"
+#EXTRAPACKAGES=ccache
+#BINDMOUNTS="${BINDMOUNTS} ${CCACHE_DIR}"
+BINDMOUNTS="${BUILDER_REPO_DIR}:/tmp/qubes-deb"

--- a/pbuilderrc
+++ b/pbuilderrc
@@ -24,7 +24,7 @@ BUILDDIR=/build
 # Debian buildds too.  You can set it to $BUILDDIR to get a working HOME, if
 # you need to.
 BUILD_HOME=/nonexistent
-MIRRORSITE=http://httpredir.debian.org/debian
+MIRRORSITE=http://deb.debian.org/debian
 #OTHERMIRROR="deb http://www.home.com/updates/ ./"
 #export http_proxy=http://your-proxy:8080/
 USEPROC=yes
@@ -98,6 +98,10 @@ DEBBUILDOPTS="-sa"
 
 #APT configuration files directory
 APTCONFDIR=""
+
+export DEB_VENDOR=Qubes
+
+unset MAKEFLAGS
 
 # the username and ID used by pbuilder, inside chroot. Needs fakeroot, really
 BUILDUSERNAME=pbuilder

--- a/pbuilderrc
+++ b/pbuilderrc
@@ -133,6 +133,8 @@ DEBOOTSTRAPOPTS=(
 # or unset it to make it not a buildd type.
 # unset DEBOOTSTRAPOPTS
 
+DEBOOTSTRAPOPTS+=( "--keyring=${DEBIAN_PLUGIN_DIR}/keys/${DISTRIBUTION}-${DIST_VENDOR}-archive-keyring.gpg" )
+
 # Keyrings to use for package verification with apt, not used for debootstrap
 # (use DEBOOTSTRAPOPTS). By default the debian-archive-keyring package inside
 # the chroot is used.

--- a/pbuilderrc
+++ b/pbuilderrc
@@ -28,10 +28,10 @@ case ${DISTRIBUTION} in
 esac
 
 
-BASETGZ="${CHROOT_DIR}/base.tgz"
+BASETGZ="${CHROOT_DIR}/pbuilder/base.tgz"
 #EXTRAPACKAGES=""
 #export DEBIAN_BUILDARCH=athlon
-BUILDPLACE=$CHROOT_DIR/build
+BUILDPLACE=$CHROOT_DIR/pbuilder/build
 # directory inside the chroot where the build happens. See #789404
 BUILDDIR=/build
 # what be used as value for HOME during builds.  See #441052
@@ -47,7 +47,7 @@ USEDEVPTS=yes
 USESYSFS=yes
 USENETWORK=no
 USERUNSHM=yes
-BUILDRESULT="${CHROOT_DIR}/results"
+BUILDRESULT="${CHROOT_DIR}/pbuilder/results"
 
 # specifying the distribution forces the distribution on "pbuilder update"
 #DISTRIBUTION=sid
@@ -138,8 +138,8 @@ DEBOOTSTRAPOPTS+=( "--keyring=${DEBIAN_PLUGIN_DIR}/keys/${DISTRIBUTION}-${DIST_V
 # Keyrings to use for package verification with apt, not used for debootstrap
 # (use DEBOOTSTRAPOPTS). By default the debian-archive-keyring package inside
 # the chroot is used.
-if [ -r "${CHROOT_DIR}/qubes-keyring.gpg" ]; then
-    APTKEYRINGS=( "${CHROOT_DIR}/qubes-keyring.gpg" )
+if [ -r "${CHROOT_DIR}/pbuilder/qubes-keyring.gpg" ]; then
+    APTKEYRINGS=( "${CHROOT_DIR}/pbuilder/qubes-keyring.gpg" )
 else
     APTKEYRINGS=()
 fi

--- a/pbuilderrc
+++ b/pbuilderrc
@@ -13,6 +13,21 @@ LOGLEVEL=I
 # no   => never use colors
 USECOLORS=auto
 
+case ${DISTRIBUTION} in
+    wheezy|jessie|stretch|buster|sid|experimental)
+        DIST_VENDOR=debian
+        MIRRORSITE=http://deb.debian.org/debian
+        ;;
+    trusty|xenial|bionic)
+        DIST_VENDOR=qubuntu
+        MIRRORSITE=http://archive.ubuntu.com/ubuntu
+        ;;
+    *)
+        echo "Unknown distribution: ${DISTRIBUTION}" >&2
+        exit 1
+esac
+
+
 BASETGZ=/var/cache/pbuilder/base.tgz
 #EXTRAPACKAGES=""
 #export DEBIAN_BUILDARCH=athlon
@@ -24,7 +39,6 @@ BUILDDIR=/build
 # Debian buildds too.  You can set it to $BUILDDIR to get a working HOME, if
 # you need to.
 BUILD_HOME=/nonexistent
-MIRRORSITE=http://deb.debian.org/debian
 #OTHERMIRROR="deb http://www.home.com/updates/ ./"
 #export http_proxy=http://your-proxy:8080/
 USEPROC=yes

--- a/pbuilderrc
+++ b/pbuilderrc
@@ -28,7 +28,7 @@ case ${DISTRIBUTION} in
 esac
 
 
-BASETGZ=/var/cache/pbuilder/base.tgz
+BASETGZ="${CHROOT_DIR}/base.tgz"
 #EXTRAPACKAGES=""
 #export DEBIAN_BUILDARCH=athlon
 BUILDPLACE=$CHROOT_DIR/build

--- a/update-local-repo.sh
+++ b/update-local-repo.sh
@@ -7,6 +7,7 @@ set -e
 REPO_DIR=$BUILDER_REPO_DIR
 DIST=$1
 
+mkdir -p $REPO_DIR
 cd $REPO_DIR
 mkdir -p dists/$DIST/main/binary-amd64
 dpkg-scanpackages --multiversion . > dists/$DIST/main/binary-amd64/Packages


### PR DESCRIPTION
Use pbuilder for build environment preparation

This replace custom code based on debootstrap and apt-get. The major
gain here is much smaller build environment (only declared dependencies
are installed), and also sharing tools with the upstream. Also it
simplifies the builder a lot.

The downside is slower operation (pbuilder re-install all the build dependencies each time).

This work was done collectively with @HW42, during Reproducible Builds Summit.

QubesOS/qubes-issues#816

Tests to do before merging:
 - [x] build all the R4.0 packages
 - [x] build all the R4.0 packages again and check for any non-reproducible -> create separate issue if any
 - [x] build all the R3.2 packages