### PR TITLE
Remove apt repos for Ubuntu (since they dont exist)

### DIFF
--- a/template_debian/distribution.sh
+++ b/template_debian/distribution.sh
@@ -433,17 +433,18 @@ installQubesRepo() {
     cat > "${INSTALLDIR}/etc/apt/sources.list.d/qubes-builder.list" <<EOF
 deb [trusted=yes] file:/tmp/qubes_repo ${DIST} main
 EOF
-    if [ -n "$USE_QUBES_REPO_VERSION" ]; then
-        cat >> "${INSTALLDIR}/etc/apt/sources.list.d/qubes-builder.list" <<EOF
-deb [arch=amd64] https://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm $DIST main
-EOF
-       if [ "0$USE_QUBES_REPO_TESTING" -gt 0 ]; then
-          cat >> "${INSTALLDIR}/etc/apt/sources.list.d/qubes-builder.list" <<EOF
-deb [arch=amd64] https://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm ${DIST}-testing main
-EOF
-        fi
+# TODO: Fix or remove the following code - apt repos for ubuntu on qubesos
+#    if [ -n "$USE_QUBES_REPO_VERSION" ]; then
+#        cat >> "${INSTALLDIR}/etc/apt/sources.list.d/qubes-builder.list" <<EOF
+#deb [arch=amd64] https://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm $DIST main
+#EOF
+#       if [ "0$USE_QUBES_REPO_TESTING" -gt 0 ]; then
+#          cat >> "${INSTALLDIR}/etc/apt/sources.list.d/qubes-builder.list" <<EOF
+#deb [arch=amd64] https://deb.qubes-os.org/r${USE_QUBES_REPO_VERSION}/vm ${DIST}-testing main
+#EOF
+#        fi
         chroot_cmd apt-key add - < ${SCRIPTSDIR}/../keys/qubes-debian-r${USE_QUBES_REPO_VERSION}.asc
-    fi
+#    fi
 }
 
 # ==============================================================================


### PR DESCRIPTION
This PR resolves an issue building any Ubuntu / qUbuntu distro at all since they reference an apt repo for qubes-os but sadly there is no support for any Ubuntu flavor distros on that server at all.

The ideal fix would be for QubesOS to add support for at least xenial and bionic but until that time - this resolves a bug which breaks any build (due to a 404 returned by apt.)