### PR TITLE
Switch from keepassx to keepassxc in buster

### DIFF
--- a/template_debian/packages_buster_standard.list
+++ b/template_debian/packages_buster_standard.list
@@ -1,7 +1,7 @@
 locales
 firefox-esr
 thunderbird
-keepassx
+keepassxc
 git
 gnome-terminal
 nautilus


### PR DESCRIPTION
Switch to a maintained fork. It's available in >= buster only.

Fixes QubesOS/qubes-issues#3542