### PR TITLE
Add new firmware target with wider range drivers

### DIFF
--- a/template_debian/firmware/02_install_groups_packages_installed.sh
+++ b/template_debian/firmware/02_install_groups_packages_installed.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+# vim: set ts=4 sw=4 sts=4 et :
+
+source "${SCRIPTSDIR}/vars.sh"
+source "${SCRIPTSDIR}/distribution.sh"
+
+#### '----------------------------------------------------------------------
+info ' Installing firmware'
+#### '----------------------------------------------------------------------
+chroot_cmd sh -c 'echo "firmware-ipw2x00 firmware-ipw2x00/license/accepted select true" |debconf-set-selections'
+packages="atmel-firmware firmware-ath9k-htc firmware-atheros firmware-brcm80211 firmware-ipw2x00 firmware-intelwimax firmware-iwlwifi firmware-misc-nonfree firmware-ralink firmware-realtek firmware-zd1211 "
+aptInstall $packages


### PR DESCRIPTION
QubesOS/qubes-issues#5123

Needs additional "firmware" target set in qubes-builder, currently waiting on merge of QubesOS/qubes-builder/pull/84