### PR TITLE
template: add alsa-utils

### DIFF
--- a/template_debian/packages_bullseye_standard.list
+++ b/template_debian/packages_bullseye_standard.list
@@ -1,3 +1,4 @@
+alsa-utils
 apt-transport-https
 cryptsetup
 cups

--- a/template_debian/packages_buster_standard.list
+++ b/template_debian/packages_buster_standard.list
@@ -1,3 +1,4 @@
+alsa-utils
 apt-transport-https
 cryptsetup
 cups

--- a/template_debian/packages_stretch_standard.list
+++ b/template_debian/packages_stretch_standard.list
@@ -1,3 +1,4 @@
+alsa-utils
 apt-transport-https
 cryptsetup
 cups


### PR DESCRIPTION
It is needed to save/restore volume values for hardware audio devices.
This is important in template for two cases:
 - AudioVM
 - audio via qemu-emulated device (useful for tests mostly)

Without alsa-utils package installed, default volume is close to zero.