### PR TITLE
Add Ubuntu 20.04 LTS (Focal Fossa) support

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -9,7 +9,7 @@ ifneq (,$(findstring $(DIST),wheezy jessie stretch buster bullseye))
     DIST_TAG := $(strip $(subst buster, deb10, $(DIST_TAG)))
     DIST_TAG := $(strip $(subst bullseye, deb11, $(DIST_TAG)))
 endif
-ifneq (,$(findstring $(DIST),trusty xenial bionic))
+ifneq (,$(findstring $(DIST),trusty xenial bionic focal))
     DEBIAN_PLUGIN_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
     TEMPLATE_ENV_WHITELIST += SYSTEMD_NSPAWN_ENABLE
     DISTRIBUTION := qubuntu

--- a/keys/focal-qubuntu-archive-keyring.gpg
+++ b/keys/focal-qubuntu-archive-keyring.gpg
@@ -1,0 +1,1 @@
+bionic-qubuntu-archive-keyring.gpg

--- a/pbuilderrc
+++ b/pbuilderrc
@@ -18,7 +18,7 @@ case ${DISTRIBUTION} in
         DIST_VENDOR=debian
         MIRRORSITE=http://deb.debian.org/debian
         ;;
-    trusty|xenial|bionic)
+    trusty|xenial|bionic|focal)
         DIST_VENDOR=qubuntu
         MIRRORSITE=http://archive.ubuntu.com/ubuntu
         ;;

--- a/template_qubuntu/02_install_groups_focal.sh
+++ b/template_qubuntu/02_install_groups_focal.sh
@@ -1,0 +1,1 @@
+02_install_groups_bionic.sh

--- a/template_qubuntu/appmenus_focal
+++ b/template_qubuntu/appmenus_focal
@@ -1,0 +1,1 @@
+/home/user/qubes-builder/qubes-src/builder-debian/template_qubuntu/appmenus_bionic

--- a/template_qubuntu/appmenus_focal_desktop
+++ b/template_qubuntu/appmenus_focal_desktop
@@ -1,0 +1,1 @@
+/home/user/qubes-builder/qubes-src/builder-debian/template_qubuntu/appmenus_bionic_desktop

--- a/template_qubuntu/packages_focal.list
+++ b/template_qubuntu/packages_focal.list
@@ -1,0 +1,1 @@
+packages_bionic.list


### PR DESCRIPTION
This configuration installs only `qubes-vm-dependencies`. As `qubes-vm-recommended` is not installed also `qubes-core-agent-passwordless-root` is missing and password-less root login doesn't work (compared to bionic).