### PR TITLE
Add link to packages_qubes_standard.list in Ubuntu template

### DIFF
--- a/template_qubuntu/packages_qubes_standard.list
+++ b/template_qubuntu/packages_qubes_standard.list
@@ -1,0 +1,1 @@
+../template_debian/packages_qubes_standard.list


### PR DESCRIPTION
Closes  QubesOS/qubes-issues#6307