### PR TITLE
Include systemd-timesyncd in default Debian template

### DIFF
--- a/template_debian/packages.list
+++ b/template_debian/packages.list
@@ -20,3 +20,4 @@ vim-nox
 xdg-user-dirs
 xsettingsd
 gnupg
+systemd-timesyncd


### PR DESCRIPTION
This is necessary for qube to work as ClockVM.

Fixes: QubesOS/qubes-issues#8173