### PR TITLE
Fix cleanup at the end of template build

### DIFF
--- a/template_debian/distribution.sh
+++ b/template_debian/distribution.sh
@@ -53,7 +53,7 @@ function umount_all() {
 
     # Only remove dirvert policies, etc if base INSTALL_DIR mount is being umounted
     if [ "${directory}" == "${INSTALL_DIR}" ] || [ "${directory}" == "${INSTALL_DIR}/" ]; then
-        if [ -n "$(mountPoints)" ]; then
+        if [ -n "$(mountPoints "$directory")" ]; then
             removeDbusUuid
             removeDivertPolicy
         fi


### PR DESCRIPTION
umount_all() should cleanup diverted policy-rc.d when unmounting final
template build dir, but the check for that was broken.
Legacy template builder called the script in the build directory
directly, but it isn't the case in builderv2, so explicit directory
parameter needs to be set.

Fixes QubesOS/qubes-issues#8316