### PR TITLE
Remove wireless tools from minimal template

### DIFF
--- a/template_debian/packages_minimal.list
+++ b/template_debian/packages_minimal.list
@@ -11,6 +11,4 @@ libglib2.0-bin
 ltrace
 strace
 haveged
-wireless-tools
-wpasupplicant
 dbus-x11


### PR DESCRIPTION
wireless-tools and wpasupplicant are safe to remove, no qubes dependencies on them.