### PR TITLE
Remove strace and ltrace

### DIFF
--- a/template_debian/packages_minimal.list
+++ b/template_debian/packages_minimal.list
@@ -8,7 +8,5 @@ gnupg
 xterm
 libfile-mimeinfo-perl
 libglib2.0-bin
-ltrace
-strace
 haveged
 dbus-x11


### PR DESCRIPTION
strace and ltrace are debugging tools, and no other tools depend on them.

Safe to remove.