### PR TITLE
Remove haveged and dbus-x11

### DIFF
--- a/template_debian/packages_minimal.list
+++ b/template_debian/packages_minimal.list
@@ -8,5 +8,3 @@ gnupg
 xterm
 libfile-mimeinfo-perl
 libglib2.0-bin
-haveged
-dbus-x11


### PR DESCRIPTION
These 2 packages are unnecessary/extra, nothing depends on them.

haveged: for kernels not in use anymore.

dbus-x11: useless in nowadays DEs

Safe to remove.