### PR TITLE
Remove xterm and libfile-mimeinfo-perl both has no effect on the temp…

### DIFF
--- a/template_debian/packages_minimal.list
+++ b/template_debian/packages_minimal.list
@@ -3,6 +3,4 @@ sudo
 dmsetup
 psmisc
 gnupg
-xterm
-libfile-mimeinfo-perl
 libglib2.0-bin


### PR DESCRIPTION
```
user@Debian-full:~$ sudo apt remove --purge libfile-mimeinfo-perl*
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'libfile-mimeinfo-perl' for glob 'libfile-mimeinfo-perl*'
The following packages were automatically installed and are no longer required:
  libfile-basedir-perl libfile-desktopentry-perl libio-stringy-perl libipc-system-simple-perl
Use 'sudo apt autoremove' to remove them.
The following packages will be REMOVED:
  libfile-mimeinfo-perl*
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 119 kB disk space will be freed.
Do you want to continue? [Y/n] 
```

or xterm, doesnt remove any qubes package.