### PR TITLE
Remove packages which are already called by other qubes dependencies

### DIFF
--- a/template_debian/packages_minimal.list
+++ b/template_debian/packages_minimal.list
@@ -1,2 +1,3 @@
 xterm
 libfile-mimeinfo-perl
+gnupg

--- a/template_debian/packages_minimal.list
+++ b/template_debian/packages_minimal.list
@@ -1,8 +1,2 @@
-ncurses-term
-sudo
-dmsetup
-psmisc
-gnupg
 xterm
 libfile-mimeinfo-perl
-libglib2.0-bin


### PR DESCRIPTION
These are dependents by qubes packages, no need to be duplicate in packages minimal.