### PR TITLE
Add bookworm-backports and install firmware packages from there

### DIFF
--- a/template_debian/distribution.sh
+++ b/template_debian/distribution.sh
@@ -325,6 +325,20 @@ function updateDebianSourceList() {
     if ! grep -r -q "$source" "${list}"*; then
         echo -e "$source\n" >> "${list}"
     fi
+    if [ "${DIST_CODENAME}" = "bookworm" ]; then
+        # make bookworm-backports available for newer firmware packages,
+        # but it needs to be explicitly selected for a package to be installed
+        # from there
+        source="deb https://deb.debian.org/debian ${DEBIANVERSION}-backports main contrib $nonfree"
+        if ! grep -r -q "$source" "${list}"*; then
+            echo -e "$source\n" >> "${list}"
+        fi
+
+        source="#deb-src https://deb.debian.org/debian ${DEBIANVERSION}-backports main contrib $nonfree"
+        if ! grep -r -q "$source" "${list}"*; then
+            echo -e "$source\n" >> "${list}"
+        fi
+    fi
 }
 
 # ==============================================================================

--- a/template_debian/firmware/02_install_groups_packages_installed.sh
+++ b/template_debian/firmware/02_install_groups_packages_installed.sh
@@ -11,4 +11,8 @@ info ' Installing firmware'
 #### '----------------------------------------------------------------------
 chroot_cmd sh -c 'echo "firmware-ipw2x00 firmware-ipw2x00/license/accepted select true" |debconf-set-selections'
 read -r -a packages <<<"atmel-firmware firmware-ath9k-htc firmware-atheros firmware-brcm80211 firmware-ipw2x00 firmware-iwlwifi firmware-misc-nonfree firmware-ralink firmware-realtek firmware-zd1211"
-aptInstall "${packages[@]}"
+if [ "${DIST_CODENAME}" = "bookworm" ]; then
+    aptInstall -t ${DIST_CODENAME}-backports
+else
+    aptInstall "${packages[@]}"
+fi


### PR DESCRIPTION
New hardware requires newer firmware packages too. This especially
applies to wifi in Novacustom V5xx and Framework laptops.

Fixes QubesOS/qubes-issues#9522