### PR TITLE
Support installing kernel in template even for minimal flavors

### DIFF
--- a/template_debian/04_install_qubes.sh
+++ b/template_debian/04_install_qubes.sh
@@ -49,7 +49,7 @@ if ! [ -f "${INSTALL_DIR}/${TMPDIR}/.prepared_qubes" ]; then
     #### '----------------------------------------------------------------------
     installPackages packages_qubes.list
 
-    if ! containsFlavor "minimal" && [ "0$TEMPLATE_ROOT_WITH_PARTITIONS" -eq 1 ]; then
+    if ! containsFlavor "minimal" || containsFlavor "install-kernel" && [ "0$TEMPLATE_ROOT_WITH_PARTITIONS" -eq 1 ]; then
         #### '------------------------------------------------------------------
         info ' Install kernel and bootloader'
         #### '------------------------------------------------------------------


### PR DESCRIPTION
To have a minimal template that includes kernel package, add an
"install-kernel" template option. This is especially useful for Whonix
templates, which are based on the minimal flavor, but will be switching
to the in-vm kernel.

QubesOS/qubes-issues#9570