### PR TITLE
Fix Thunar desktop name

### DIFF
--- a/template_debian/appmenus_bookworm_xfce/vm-whitelisted-appmenus.list
+++ b/template_debian/appmenus_bookworm_xfce/vm-whitelisted-appmenus.list
@@ -1,4 +1,4 @@
 xfce4-terminal.desktop
-Thunar.desktop
+thunar.desktop
 firefox-esr.desktop
 xfce-settings-manager.desktop

--- a/template_debian/appmenus_bullseye_xfce/vm-whitelisted-appmenus.list
+++ b/template_debian/appmenus_bullseye_xfce/vm-whitelisted-appmenus.list
@@ -1,4 +1,4 @@
 xfce4-terminal.desktop
-Thunar.desktop
+thunar.desktop
 firefox-esr.desktop
 xfce-settings-manager.desktop

--- a/template_debian/appmenus_buster_xfce/vm-whitelisted-appmenus.list
+++ b/template_debian/appmenus_buster_xfce/vm-whitelisted-appmenus.list
@@ -1,4 +1,4 @@
 xfce4-terminal.desktop
-Thunar.desktop
+thunar.desktop
 firefox-esr.desktop
 xfce-settings-manager.desktop

--- a/template_debian/appmenus_trixie_xfce/vm-whitelisted-appmenus.list
+++ b/template_debian/appmenus_trixie_xfce/vm-whitelisted-appmenus.list
@@ -1,4 +1,4 @@
 xfce4-terminal.desktop
-Thunar.desktop
+thunar.desktop
 firefox-esr.desktop
 xfce-settings-manager.desktop


### PR DESCRIPTION
It's thunar.desktop, not Thunar.desktop.

Fixes QubesOS/qubes-issues#10056